### PR TITLE
WEB-422: fixed size of mailto text in Contacts

### DIFF
--- a/src/components/molecules/Mailto/Mailto.styles.module.scss
+++ b/src/components/molecules/Mailto/Mailto.styles.module.scss
@@ -2,9 +2,9 @@
 
 .mailto {
   @include flex-center;
-  @include font-size;
 
   margin: 15px 12px;
+  font-size: 22px;
 
   @include mobile {
     width: 100%;

--- a/src/components/molecules/Mailto/Mailto.styles.module.scss
+++ b/src/components/molecules/Mailto/Mailto.styles.module.scss
@@ -2,9 +2,9 @@
 
 .mailto {
   @include flex-center;
+  @include font-size;
 
   margin: 15px 12px;
-  font-size: 22px;
 
   @include mobile {
     width: 100%;

--- a/src/components/molecules/Mailto/Mailto.styles.module.scss
+++ b/src/components/molecules/Mailto/Mailto.styles.module.scss
@@ -4,6 +4,7 @@
   @include flex-center;
 
   margin: 15px 12px;
+  font-size: 22px;
 
   @include mobile {
     width: 100%;

--- a/src/scss/mixins/layouts.scss
+++ b/src/scss/mixins/layouts.scss
@@ -3,7 +3,3 @@
   justify-content: center;
   align-items: center;
 }
-
-@mixin font-size {
-  font-size: 22;
-}

--- a/src/scss/mixins/layouts.scss
+++ b/src/scss/mixins/layouts.scss
@@ -3,3 +3,7 @@
   justify-content: center;
   align-items: center;
 }
+
+@mixin font-size {
+  font-size: 22;
+}


### PR DESCRIPTION
# Task

Closes #422 from WEB

## Description

* Изменил размер шрифта компонента Mailto для нормального отображения Почты в Контактах
* Использовал миксины для font size, чтобы не менять шрифт по всему сайту

Safari:

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/71666299/164458330-79d287c4-399c-437c-84a6-7b1625a9dd52.png">

Yandex: 

<img width="805" alt="image" src="https://user-images.githubusercontent.com/71666299/164458485-4d5a0e2f-149a-4127-8eec-e0620f48be32.png">

